### PR TITLE
fixed cert loading bug and updated pkg version

### DIFF
--- a/Domain/Sia.Shared/Authentication/Certificates/LocalCertificateRetriever.cs
+++ b/Domain/Sia.Shared/Authentication/Certificates/LocalCertificateRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Sia.Shared.Validation;
+using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -32,11 +33,13 @@ namespace Sia.Shared.Authentication
                 using (X509Store store = new X509Store("My", location))
                 {
                     store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
-                    X509Certificate2Collection certificates = store.Certificates.Find(X509FindType.FindByThumbprint, _certThumbprint, true);
-
+                    X509Certificate2Collection certificates = store.Certificates.Find(X509FindType.FindByThumbprint, _certThumbprint, false);
                     if (certificates.Count > 0)
+                    {
                         return Task.FromResult(certificates[0]);
+                    }
                 }
+
             }
             throw new KeyNotFoundException("Could not find valid certificate");
         }

--- a/Domain/Sia.Shared/Sia.Shared.csproj
+++ b/Domain/Sia.Shared/Sia.Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.1.20-alpha</Version>
+    <Version>1.1.25-alpha</Version>
     <PackageId>Microsoft.Sia.Shared</PackageId>
     <Authors>pdimit, magpint, jache, chtownes</Authors>
     <Company>Microsoft</Company>

--- a/Domain/Sia.Shared/Sia.Shared.csproj
+++ b/Domain/Sia.Shared/Sia.Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.1.7-alpha</Version>
+    <Version>1.1.20-alpha</Version>
     <PackageId>Microsoft.Sia.Shared</PackageId>
     <Authors>pdimit, magpint, jache, chtownes</Authors>
     <Company>Microsoft</Company>


### PR DESCRIPTION
The last arg in that Certificates.Find method is a bool to only find valid certs.  Our cert is valid for our purposes but didn't match the validity definition for the method.  Using the more permissive arg lets us load the cert for the ticketing system and get the ticket data.  This took a while to find and required multiple iterations.  Hence the version change.